### PR TITLE
Rotate the Jenkins logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 pipeline {
 	agent any
 
-  environment {
+	options { buildDiscarder(logRotator(numToKeepStr: '5')) }
+
+	environment {
 		CMAKE_DIR = '/usr/local/bin'
 	}
 


### PR DESCRIPTION
The server disk filled up. This should keep usage lower I hope.